### PR TITLE
Patch tags style on event detail page

### DIFF
--- a/BaseBillet/templates/reunion/views/event/retrieve.html
+++ b/BaseBillet/templates/reunion/views/event/retrieve.html
@@ -107,7 +107,7 @@
         <!-- tags -->
         <p>
             {% for tag  in event.tag.all %}
-                <span class="badge text-bg-info p-2 me-1 fs-6 fw-medium">{{ tag }}</span>
+                <span style="{{ tag.style_attr }}" class="badge p-2 me-1 fs-6 fw-medium">{{ tag }}</span>
             {% endfor %}
         </p>
 


### PR DESCRIPTION
Correction du style des tags sur la page de détail d'un évenement (voir #283) : 
Avant :
<img width="592" height="124" alt="image" src="https://github.com/user-attachments/assets/a32e33da-01f4-4846-8a34-424c8e7410fe" />

Après :
<img width="592" height="124" alt="image" src="https://github.com/user-attachments/assets/ea4f3389-9ae5-48bd-ade4-226a33361452" />
