### PR TITLE
Replace tags on event detail page by a link for easier research (like on crowds)

### DIFF
--- a/BaseBillet/templates/reunion/views/event/retrieve.html
+++ b/BaseBillet/templates/reunion/views/event/retrieve.html
@@ -118,8 +118,16 @@
 
         <!-- tags -->
         <p>
-            {% for tag  in event.tag.all %}
-                <span style="{{ tag.style_attr }}" class="badge p-2 me-1 fs-6 fw-medium">{{ tag }}</span>
+            {% for tag in event.tag.all %}
+                <a class="btn btn-sm mb-1"
+                    style="{{ tag.style_attr }}"
+                    href="{% url 'event-list' %}?tag={{ tag.slug }}{% if search %}&search={{ search|urlencode }}{% endif %}"
+                    hx-get="{% url 'event-list' %}?tag={{ tag.slug }}{% if search %}&search={{ search|urlencode }}{% endif %}"
+                    hx-target="body"
+                    hx-swap="innerHTML"
+                    hx-push-url="true">
+                    {{ tag.name }}
+                </a>
             {% endfor %}
         </p>
 


### PR DESCRIPTION
Remplacement des tags sur la page détail d'un évenement par des liens pour permettre une recherche plus faciles (comme ce qu'il y a déjà sur crowds)