### PR TITLE
Replace date with datetime in federated_events_filter to fix #342

### DIFF
--- a/BaseBillet/views.py
+++ b/BaseBillet/views.py
@@ -1687,7 +1687,7 @@ class EventMVT(viewsets.ViewSet):
                     event.img = event.get_img()
                     event.sticker_img = event.get_sticker_img()
 
-                    date = event.datetime.date()
+                    date = event.datetime
                     # setdefault pour éviter de faire un if date exist dans le dict
                     dated_events.setdefault(date, []).append(event)
 


### PR DESCRIPTION
Quand la date s'affichait, sur la page détail c'était un objet datetime donc le changement de timezone fonctionnait. Alors que sur la page liste, c'était un juste une date, donc impossible pour django de faire le changement de timezone. (fix #342)

<img width="1916" height="776" alt="image" src="https://github.com/user-attachments/assets/c69918a5-3179-41a4-bbd1-cb6ea49522fd" />
