### PR TITLE
Correction prix libre manquant depuis les produits de caisses dans l'admin

### DIFF
--- a/Administration/admin/products.py
+++ b/Administration/admin/products.py
@@ -524,7 +524,7 @@ class POSPriceInline(BasePriceInline):
 
     fields = (
         "name",
-        "prix",
+        ("prix", "free_price"),
         "poids_mesure",
         "contenance",
         "non_fiduciaire",


### PR DESCRIPTION
avant :
<img width="1760" height="626" alt="image" src="https://github.com/user-attachments/assets/308a7781-f188-41ed-9e45-84005a629d6d" />
après :
<img width="1760" height="626" alt="Capture d’écran du 2026-05-04 17-57-43" src="https://github.com/user-attachments/assets/9065712e-4f53-462a-9ee1-d79245ffa7b9" />
