### PR TITLE
Issue 431 cancel ticket htmx toast

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/BaseBillet/templates/reunion/partials/toasts.html
+++ b/BaseBillet/templates/reunion/partials/toasts.html
@@ -41,3 +41,61 @@
     {% endfor %}
     {% endif %}
 </div>
+
+<script>
+    // FR: Issue #431 — écoute l'évènement "toast" émis via HX-Trigger (pattern GUIDELINES
+    //     "HX-Trigger + django.messages") et reproduit le markup Bootstrap serveur ci-dessus.
+    // EN: Issue #431 — listens for the "toast" event sent via HX-Trigger (GUIDELINES
+    //     "HX-Trigger + django.messages" pattern) and replicates the server-side Bootstrap
+    //     markup above.
+    if (!window.__tibilletToastListener) {
+        window.__tibilletToastListener = true;
+        document.body.addEventListener('toast', function (e) {
+            const items = e && e.detail && e.detail.items;
+            if (!items || !items.length) return;
+            const container = document.getElementById('toastContainer');
+            if (!container) return;
+            // FR: Mêmes styles/labels que le rendu serveur ci-dessus.
+            // EN: Same styles/labels as the server-side rendering above.
+            const levels = {
+                'success': {css: 'text-bg-success', label: '{% trans 'Success' as l_success %}{{ l_success|escapejs }}'},
+                'info': {css: 'text-bg-info', label: '{% trans 'Heads up' as l_info %}{{ l_info|escapejs }}'},
+                'warning': {css: 'text-bg-warning', label: '{% trans 'Warning' as l_warning %}{{ l_warning|escapejs }}'},
+                'error': {css: 'text-bg-danger', label: '{% trans 'Error' as l_error %}{{ l_error|escapejs }}'},
+                'debug': {css: 'text-bg-secondary', label: '{% trans 'Debug' as l_debug %}{{ l_debug|escapejs }}'}
+            };
+            items.forEach(function (item) {
+                const level = levels[item.level] || levels['info'];
+                const toast = document.createElement('div');
+                toast.className = 'toast show';
+                toast.setAttribute('aria-atomic', 'true');
+                toast.setAttribute('role', item.level === 'error' ? 'alert' : 'status');
+                toast.setAttribute('aria-live', item.level === 'error' ? 'assertive' : 'polite');
+
+                const header = document.createElement('div');
+                header.className = 'd-flex flex-row justify-content-between toast-header rounded-top ' + level.css;
+                header.appendChild(document.createTextNode(level.label));
+                const closeBtn = document.createElement('button');
+                closeBtn.type = 'button';
+                closeBtn.className = 'btn-close';
+                closeBtn.setAttribute('data-bs-dismiss', 'toast');
+                closeBtn.setAttribute('aria-label', '{% trans 'Close' as l_close %}{{ l_close|escapejs }}');
+                header.appendChild(closeBtn);
+                toast.appendChild(header);
+
+                const hr = document.createElement('hr');
+                hr.className = 'horizontal dark m-0';
+                toast.appendChild(hr);
+
+                const body = document.createElement('div');
+                body.className = 'toast-body';
+                // FR: textContent (et non innerHTML) pour éviter toute injection XSS.
+                // EN: textContent (not innerHTML) to avoid any XSS injection.
+                body.textContent = item.text || '';
+                toast.appendChild(body);
+
+                container.appendChild(toast);
+            });
+        });
+    }
+</script>

--- a/BaseBillet/views.py
+++ b/BaseBillet/views.py
@@ -13,7 +13,7 @@ import segno
 import stripe
 from django.contrib import messages
 from django.contrib.auth import logout, login
-from django.contrib.messages import MessageFailure
+from django.contrib.messages import MessageFailure, get_messages
 from django.core import signing
 from django.core.cache import cache
 from django.core.paginator import Paginator
@@ -899,14 +899,32 @@ class MyAccount(viewsets.ViewSet):
             except Exception as ce:
                 logger.error(f"Failed to queue cancellation email for ticket {ticket.uuid}: {ce}")
             if request.headers.get('HX-Request'):
-                return HttpResponse("")
+                # FR: Issue #431 — pattern GUIDELINES "HX-Trigger + django.messages" :
+                #     on draine les messages en attente et on les envoie au client via
+                #     l'entête HX-Trigger pour afficher le toast sans rechargement.
+                # EN: Issue #431 — GUIDELINES "HX-Trigger + django.messages" pattern:
+                #     drain queued messages and ship them through the HX-Trigger header
+                #     so the toast shows without a full page reload.
+                payload = [{"level": m.level_tag, "text": str(m)} for m in get_messages(request)]
+                response = HttpResponse("")
+                response["HX-Trigger"] = json.dumps({"toast": {"items": payload}})
+                return response
             return HttpResponseClientRedirect('/my_account/my_reservations/')
         except Exception as e:
             logger.error(f"Error canceling ticket {pk}: {e}")
             messages.add_message(request, messages.ERROR,
                                  _("An error occurred while cancelling your ticket.") + f" : {e}")
             if request.headers.get('HX-Request'):
-                return HttpResponse("", status=400)
+                # FR: Statut 400 — htmx ne swappe pas (le billet n'est PAS annulé, la ligne
+                #     reste affichée) mais traite quand même l'entête HX-Trigger : le toast
+                #     d'erreur s'affiche. (Issue #431)
+                # EN: Status 400 — htmx does not swap (ticket NOT cancelled, row stays)
+                #     but still processes the HX-Trigger header: the error toast shows.
+                #     (Issue #431)
+                payload = [{"level": m.level_tag, "text": str(m)} for m in get_messages(request)]
+                response = HttpResponse("", status=400)
+                response["HX-Trigger"] = json.dumps({"toast": {"items": payload}})
+                return response
             return HttpResponseClientRedirect('/my_account/my_reservations/')
 
     @action(detail=False, methods=['GET'])

--- a/tests/pytest/test_cancel_ticket_htmx_toast.py
+++ b/tests/pytest/test_cancel_ticket_htmx_toast.py
@@ -1,0 +1,214 @@
+"""
+Test DB-only : MyAccount.cancel_ticket — toast HTMX via l'entête HX-Trigger.
+/ DB-only test: MyAccount.cancel_ticket — HTMX toast through the HX-Trigger header.
+
+CONTEXTE (issue #431) :
+"Quand on annule un billet, le message de confirmation s'affiche après un
+reload et pas directement." L'annulation d'un billet passait par
+HttpResponseClientRedirect : le message django.messages n'était affiché
+qu'après le rechargement complet de la page.
+
+LE CORRECTIF : la branche HTMX de MyAccount.cancel_ticket (BaseBillet/views.py)
+draine les django.messages en attente et les embarque dans l'entête
+HX-Trigger (payload {"toast": {"items": [{"level", "text"}]}}) pour que le
+toast s'affiche immédiatement, sans reload :
+- succès : HttpResponse("") 200 + HX-Trigger (level "success") ;
+- erreur : HttpResponse("", status=400) + HX-Trigger (level "error"),
+  htmx ne swappe pas (la ligne du billet reste affichée) mais traite
+  quand même l'entête HX-Trigger.
+La branche NON-HTMX garde le comportement HttpResponseClientRedirect
+(entête HX-Redirect vers /my_account/my_reservations/).
+
+/ CONTEXT (issue #431): "When cancelling a ticket, the confirmation message
+only shows after a reload, not immediately." The HTMX branch of cancel_ticket
+must ship queued django.messages through the HX-Trigger header so the toast
+displays immediately; the non-HTMX branch keeps the HX-Redirect behavior.
+
+Lancer / Run :
+  docker exec lespass_django poetry run pytest tests/pytest/test_cancel_ticket_htmx_toast.py -v
+"""
+import json
+import uuid
+from datetime import timedelta
+from unittest.mock import patch
+
+import pytest
+from django.test.client import Client as DjangoClient
+from django.utils import timezone
+from django_tenants.utils import tenant_context
+
+pytestmark = pytest.mark.django_db
+
+
+def _creer_user_connectable(tenant, suffix):
+    """
+    Cree un utilisateur capable de passer MyAccount.dispatch :
+    - is_active=True (get_or_create_user cree des users INACTIFS ; un user
+      inactif redevient AnonymousUser au chargement de session -> redirect '/') ;
+    - wallet local (sans wallet, dispatch appelle FedowAPI -> reseau).
+    IMPORTANT : activer AVANT de creer la reservation — le passage
+    is_active False->True declenche activator_free_reservation (signals.py).
+    / Creates a user able to pass MyAccount.dispatch: active (inactive users
+    resolve to AnonymousUser on session load -> redirect '/') and with a local
+    wallet (without one, dispatch calls FedowAPI -> network). Activate BEFORE
+    creating the reservation — the False->True transition triggers
+    activator_free_reservation (signals.py).
+    """
+    from AuthBillet.models import Wallet
+    from AuthBillet.utils import get_or_create_user
+
+    user = get_or_create_user(f"cancel_ticket_htmx_{suffix}@example.com", send_mail=False)
+    user.is_active = True
+    user.wallet = Wallet.objects.create(origin=tenant)
+    user.save(update_fields=["is_active", "wallet"])
+    return user
+
+
+def _creer_resa_avec_ticket(user, suffix, ticket_status):
+    """
+    Event + reservation + UN ticket GRATUIT (sans pricesold ni LigneArticle) :
+    cancel_and_refund_ticket prend alors la voie sans remboursement — aucun
+    appel Stripe (total_paid()==0, aucune ligne hors-Stripe ne matche).
+    / Event + reservation + ONE FREE ticket (no pricesold, no LigneArticle):
+    cancel_and_refund_ticket takes the no-refund path — no Stripe call
+    (total_paid()==0, no non-Stripe line matches).
+    """
+    from BaseBillet.models import Event, Reservation, Ticket
+
+    event = Event.objects.create(
+        name=f"AnnulBillet_{suffix}",
+        datetime=timezone.now() + timedelta(days=7),
+    )
+    reservation = Reservation.objects.create(user_commande=user, event=event)
+    ticket = Ticket.objects.create(reservation=reservation, status=ticket_status)
+    return event, reservation, ticket
+
+
+def test_cancel_ticket_htmx_renvoie_le_toast_dans_hx_trigger(tenant):
+    """
+    POST HTMX sur cancel_ticket : 200, entête HX-Trigger avec le toast
+    de succès, et le billet passe CANCELED en DB. (Issue #431)
+    / HTMX POST on cancel_ticket: 200, HX-Trigger header carrying the
+    success toast, and the ticket is CANCELED in DB. (Issue #431)
+    """
+    with tenant_context(tenant):
+        from BaseBillet.models import Ticket
+
+        suffix = uuid.uuid4().hex[:8]
+        user = _creer_user_connectable(tenant, suffix)
+        event, reservation, ticket = _creer_resa_avec_ticket(user, suffix, Ticket.NOT_SCANNED)
+
+        client = DjangoClient(HTTP_HOST=tenant.get_primary_domain().domain)
+        client.force_login(user)
+
+        with patch("BaseBillet.views.send_ticket_cancellation_user.delay") as mock_mail:
+            response = client.post(
+                f"/my_account/{ticket.uuid}/cancel_ticket/",
+                HTTP_HX_REQUEST="true",
+            )
+
+        assert response.status_code == 200
+
+        # Le toast voyage dans l'entête HX-Trigger, pas dans le body.
+        # / The toast travels in the HX-Trigger header, not in the body.
+        trigger = response.headers.get("HX-Trigger")
+        assert trigger, "L'entête HX-Trigger doit être présente (issue #431)"
+        payload = json.loads(trigger)
+        items = payload["toast"]["items"]
+        assert isinstance(items, list) and len(items) > 0
+
+        # Assertion robuste, indépendante de la locale : niveau + texte non vide.
+        # / Locale-independent robust assertion: level + non-empty text.
+        assert items[0]["level"] == "success"
+        assert len(items[0]["text"]) > 0
+
+        ticket.refresh_from_db()
+        assert ticket.status == Ticket.CANCELED
+
+        mock_mail.assert_called_once_with(str(ticket.uuid))
+
+        # Cleanup : tickets + reservation. PAS l'event (piege stdimage 10.1).
+        # / Cleanup: tickets + reservation. NOT the event (stdimage pitfall 10.1).
+        Ticket.objects.filter(reservation=reservation).delete()
+        reservation.delete()
+
+
+def test_cancel_ticket_htmx_erreur_renvoie_le_toast_erreur(tenant):
+    """
+    Billet déjà SCANNÉ : cancel_and_refund_ticket lève ("You cannot cancel a
+    ticket that has been scanned.", models.py). La branche HTMX d'erreur
+    renvoie 400 + HX-Trigger level "error", et le billet reste SCANNED.
+    / Already SCANNED ticket: cancel_and_refund_ticket raises. The HTMX error
+    branch returns 400 + HX-Trigger level "error", ticket stays SCANNED.
+    """
+    with tenant_context(tenant):
+        from BaseBillet.models import Ticket
+
+        suffix = uuid.uuid4().hex[:8]
+        user = _creer_user_connectable(tenant, suffix)
+        event, reservation, ticket = _creer_resa_avec_ticket(user, suffix, Ticket.SCANNED)
+
+        client = DjangoClient(HTTP_HOST=tenant.get_primary_domain().domain)
+        client.force_login(user)
+
+        with patch("BaseBillet.views.send_ticket_cancellation_user.delay") as mock_mail:
+            response = client.post(
+                f"/my_account/{ticket.uuid}/cancel_ticket/",
+                HTTP_HX_REQUEST="true",
+            )
+
+        # 400 : htmx ne swappe pas (la ligne reste) mais traite HX-Trigger.
+        # / 400: htmx does not swap (row stays) but still processes HX-Trigger.
+        assert response.status_code == 400
+        trigger = response.headers.get("HX-Trigger")
+        assert trigger, "L'entête HX-Trigger doit être présente même en erreur"
+        payload = json.loads(trigger)
+        items = payload["toast"]["items"]
+        assert isinstance(items, list) and len(items) > 0
+        assert items[0]["level"] == "error"
+        assert len(items[0]["text"]) > 0
+
+        # Le billet scanné n'est PAS annulé.
+        # / The scanned ticket is NOT cancelled.
+        ticket.refresh_from_db()
+        assert ticket.status == Ticket.SCANNED
+
+        mock_mail.assert_not_called()
+
+        Ticket.objects.filter(reservation=reservation).delete()
+        reservation.delete()
+
+
+def test_cancel_ticket_sans_htmx_redirige(tenant):
+    """
+    POST SANS entête HX-Request : comportement historique conservé —
+    HttpResponseClientRedirect (django-htmx) = 200 + entête HX-Redirect vers
+    /my_account/my_reservations/. Le billet est bien CANCELED en DB.
+    / POST WITHOUT the HX-Request header: legacy behavior preserved —
+    HttpResponseClientRedirect (django-htmx) = 200 + HX-Redirect header to
+    /my_account/my_reservations/. Ticket is CANCELED in DB.
+    """
+    with tenant_context(tenant):
+        from BaseBillet.models import Ticket
+
+        suffix = uuid.uuid4().hex[:8]
+        user = _creer_user_connectable(tenant, suffix)
+        event, reservation, ticket = _creer_resa_avec_ticket(user, suffix, Ticket.NOT_SCANNED)
+
+        client = DjangoClient(HTTP_HOST=tenant.get_primary_domain().domain)
+        client.force_login(user)
+
+        with patch("BaseBillet.views.send_ticket_cancellation_user.delay"):
+            response = client.post(f"/my_account/{ticket.uuid}/cancel_ticket/")
+
+        # HttpResponseClientRedirect : HttpResponse 200 + entête HX-Redirect.
+        # / HttpResponseClientRedirect: HttpResponse 200 + HX-Redirect header.
+        assert response.status_code == 200
+        assert response.headers.get("HX-Redirect") == "/my_account/my_reservations/"
+        assert response.headers.get("HX-Trigger") is None
+
+        ticket.refresh_from_db()
+        assert ticket.status == Ticket.CANCELED
+
+        Ticket.objects.filter(reservation=reservation).delete()
+        reservation.delete()


### PR DESCRIPTION
## Fixes #431 — Show the ticket cancellation confirmation immediately, without a page reload

### Problem

When a user cancels a single ticket from `/my_account/my_reservations/`, the
confirmation message only appears after a manual page reload.

**Root cause:** the HTMX branch of `MyAccount.cancel_ticket` queued the
confirmation via `django.contrib.messages` but returned an empty
`HttpResponse("")`. Since the cancel button uses `hx-swap="delete"`, no page
render happens, so the queued message stays invisible until the next full
page load. The error branch (`HttpResponse("", status=400)`) had the same
problem.

### Solution

Implements the pattern already documented in `GUIDELINES.md`
("HX-Trigger + django.messages") and recommended in `tests/PIEGES.md` for this
exact class of problem, following the existing `HX-Trigger` precedent in the
`crowds` app:

- **`BaseBillet/views.py` — `cancel_ticket`**: both HTMX branches now drain
  the queued messages with `get_messages(request)` and ship them in the
  `HX-Trigger` response header as
  `{"toast": {"items": [{"level": "...", "text": "..."}]}}`.
  - Success: `200` → htmx performs the `hx-swap="delete"` (the ticket row
    disappears) **and** the success toast shows immediately.
  - Error: `400` → htmx does not swap on 4xx (the row correctly stays, since
    the ticket was NOT cancelled) but still processes the `HX-Trigger`
    header, so the error toast shows immediately.
  - The non-HTMX fallback (`HttpResponseClientRedirect`) is unchanged.
- **`BaseBillet/templates/reunion/partials/toasts.html`**: new global JS
  listener for the `toast` event. It replicates the exact server-side
  Bootstrap toast markup of the same partial (same classes, colors,
  aria attributes and `{% trans %}` labels) and appends the toasts into the
  existing `#toastContainer`. Since the partial is included by all four base
  templates (`reunion/base.html`, `headless.html`, `blank_base.html`,
  `faire_festival/base.html`), the listener is available on every page and
  reusable for any future HTMX partial that wants to display messages.
  - XSS-safe: message text is inserted with `textContent` (never
    `innerHTML`), labels go through `|escapejs`.
  - Header-injection-safe: `json.dumps` (default `ensure_ascii=True`)
    produces pure ASCII, so no CR/LF can reach the header value.
  - Guarded against double registration (`window.__tibilletToastListener`).
  - No new translatable strings: the listener reuses the `{% trans %}` labels
    already present in the partial — no `.po` changes needed.

### Tests

New file `tests/pytest/test_cancel_ticket_htmx_toast.py` (3 tests, all green):

1. HTMX success: `200`, `HX-Trigger` header carries the success toast
   payload, ticket is `CANCELED` in DB, cancellation email task queued once.
2. HTMX error (already-scanned ticket): `400`, `HX-Trigger` carries the
   error toast, ticket stays `SCANNED`, no email task.
3. Non-HTMX: legacy behavior preserved — `200` + `HX-Redirect` to
   `/my_account/my_reservations/`, no `HX-Trigger`.

```bash
docker exec lespass_django poetry run pytest tests/pytest/test_cancel_ticket_htmx_toast.py -v
# 3 passed
docker exec lespass_django poetry run python manage.py check
# System check identified no issues